### PR TITLE
adler32 should have an initial value of 1

### DIFF
--- a/Data/Digest/Adler32.hsc
+++ b/Data/Digest/Adler32.hsc
@@ -32,7 +32,7 @@ import qualified Data.ByteString.Lazy.Internal as LI
 class Adler32 a where
     -- | Compute Adler32 checksum
     adler32 :: a -> Word32
-    adler32 = adler32Update 0
+    adler32 = adler32Update 1
 
     -- | Given the Adler32 checksum of a string, compute Adler32 of its
     -- concatenation with another string (t.i., incrementally update the 


### PR DESCRIPTION
When checking our pure implementation of adler32 against the _digest_ implementation, we found that the checksums always mismatched. In comparing with other implementations, we found that the _digest_ implementation is in fact incorrect. The source of this error is the initial value of the adler32 function, which is 0, but should be 1. From zlib's adler32.c:

```
    /* initial Adler-32 value (deferred check for len == 1 speed) */
    if (buf == Z_NULL)
        return 1L;
```
