### PR TITLE
default bytestring-in-base flag to False

### DIFF
--- a/digest.cabal
+++ b/digest.cabal
@@ -22,6 +22,7 @@ extra-source-files:
 flag bytestring-in-base
   description: In the ghc-6.6 era the bytestring modules were
                included in the base package.
+  default: False
 
 source-repository head
   type: git


### PR DESCRIPTION
ghc-6.6 is very old now, so let's assume separate bytestring
