### PR TITLE
Use pkgconfig to find zlib

### DIFF
--- a/digest.cabal
+++ b/digest.cabal
@@ -42,6 +42,6 @@ library
   includes:        zlib.h
   ghc-options:     -Wall
   if !os(windows)
-    extra-libraries: z
+    pkgconfig-depends: zlib
   else
     build-depends: zlib


### PR DESCRIPTION
This makes library discovery significantly easier in some environments (e.g. on `nix` where bgamari/nix-pkgconfig can be used)