### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/digest.cabal
+++ b/digest.cabal
@@ -12,7 +12,7 @@ description:     This package provides efficient cryptographic hash implementati
                  they are implemented as FFI bindings to efficient code from zlib.
 stability:       provisional
 build-type:      Simple
-cabal-version:   >= 1.6
+cabal-version:   >= 1.8
 
 extra-source-files:
   testing/trivial-reference.c


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: digest.cabal:41:33: version operators used. To use version operators
the package needs to specify at least 'cabal-version: >= 1.8'.
```